### PR TITLE
Fixed error in webpack.config.js when mode == production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,7 +161,7 @@ module.exports = function(_, arg) {
   };
 
   if (arg.mode === "production") {
-    config.plugins.puch(
+    config.plugins.push(
       new AppCachePlugin({
         network: ["*"],
         settings: ["prefer-online"],


### PR DESCRIPTION
Webpack configuration file fix, appears to be a typo while processing plugins. 
